### PR TITLE
Add base class of all subcommands

### DIFF
--- a/bin/wd-claims
+++ b/bin/wd-claims
@@ -1,21 +1,16 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const chalk   = require('chalk')
 const strings = require('../lib/strings')
 
-program
-.arguments(strings.claims.args)
-.description(strings.claims.description)
-.option('-l, --lang <lang>', "specify the properties labels' language")
-.parse(process.argv)
+program.process('claims')
 
 var id = program.args[0]
 var prop = program.args[1]
-const localLang = require('../lib/local_lang')
 
 Promise = require('bluebird')
 
-const lang = program.lang || localLang || 'en'
+const lang = program.lang
 
 if (!(id && lang)) return program.help()
 

--- a/bin/wd-data
+++ b/bin/wd-data
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 
-program
-.arguments(strings.data.args)
-.description(strings.data.description)
-.parse(process.argv)
+program.process('data')
 
 var id = program.args[0]
 

--- a/bin/wd-label
+++ b/bin/wd-label
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 const chalk   = require('chalk')
 
-program
-.arguments(strings.label.args)
-.description(strings.label.description)
-.option('-l, --lang <lang>', "specify the label's language")
-.parse(process.argv)
+program.process('label')
 
 const args = program.args
 
@@ -15,10 +11,9 @@ const wdk = require('wikidata-sdk')
 const copy = require('../lib/copy')
 const breq = require('bluereq')
 const error_ = require('../lib/error')
-const localLang = require('../lib/local_lang')
 
 const id = args[0]
-const lang = program.lang || localLang || 'en'
+const lang = program.lang
 
 if (!(id && lang)) return program.help()
 

--- a/bin/wd-open
+++ b/bin/wd-open
@@ -1,23 +1,19 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 const wdk = require('wikidata-sdk')
 const error_ = require('../lib/error')
-const localLang = require('../lib/local_lang')
 const open = require('opn')
-  const getSitelinkUrl = require('../lib/get_sitelink_url')
+const getSitelinkUrl = require('../lib/get_sitelink_url')
 
-program
-.arguments(strings.open.args)
-.description(strings.open.description)
+program.
 .option('-p, --wikipedia', 'open the Wikipedia article instead')
-.option('-l, --lang <lang>', 'specify for which language the sitelink should be picked')
-.parse(process.argv)
+.process('open')
 
 const args = program.args
 if (args.length === 0) return program.help()
 
-const lang = program.lang || localLang || 'en'
+const lang = program.lang
 const idString = args[0]
 
 // Accept any string that might contain a Wikidata id and keep only the id

--- a/bin/wd-props
+++ b/bin/wd-props
@@ -1,21 +1,17 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 
 const getLangProps = require('../lib/get_lang_props')
-var localLang = require('../lib/local_lang')
 var resetProperties = require('../lib/reset_properties')
 
 program
-.arguments(strings.props.args)
-.description(strings.props.description)
 .option('-r, --reset', 'clear properties cache')
-.option('-l, --lang <lang>', 'specify the properties labels language')
-.parse(process.argv)
+.process('props')
 
 if (program.reset) return resetProperties()
 
-const lang = program.lang || localLang || 'en'
+const lang = program.lang
 
 const writeResultsToStdout = function (results) {
   console.log(JSON.stringify(results, null, 2))

--- a/bin/wd-query
+++ b/bin/wd-query
@@ -1,29 +1,25 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 const wdk = require('wikidata-sdk')
 const chalk   = require('chalk')
 const makeSparqlQuery = require('../lib/make_sparql_query')
-const localLang = require('../lib/local_lang')
 const formatStatementElementValue = require('../lib/format_statement_element_value')
 
 program
-.arguments(strings.query.args)
-.description(strings.query.description)
 .option('-s, --subject <subject>', 'set a subject')
 .option('-p, --property <property>', 'set a property')
 .option('-o, --object <object>', 'set an object')
 .option('-r, --raw', 'raw SPARQL results')
 .option('-a, --labels', 'requests results labels')
-.option('-l, --lang <lang>', "specify the labels' language")
 .option('-t, --limit <num>', 'set the request results limit (defaults to 1000)')
 .option('-d, --debug', 'log the generated request')
-.parse(process.argv)
+.process('query')
 
 if (process.argv.length === 2) return program.help()
 
 const includeLabels = program.labels
-var lang = program.lang || localLang || 'en'
+var lang = program.lang
 
 if (!(program.subject || program.property || program.object)) {
   console.log("At least one statement element should be set: subject (-s), property (-p), or object (-o)")

--- a/bin/wd-sparql
+++ b/bin/wd-sparql
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 
 program
-.arguments(strings.sparql.args)
-.description(strings.sparql.description)
 .option('-r, --raw', 'raw SPARQL results')
 .option('-d, --debug', 'log the generated request')
-.parse(process.argv)
+.process('sparql')
 
 const path = program.args[0]
 

--- a/bin/wd-wikiqid
+++ b/bin/wd-wikiqid
@@ -1,12 +1,8 @@
 #!/usr/bin/env node
-const program = require('commander')
+const program = require('../lib/program')
 const strings = require('../lib/strings')
 
-program
-.arguments(strings.wikiqid.args)
-.description(strings.wikiqid.description)
-.option('-l, --lang <lang>', 'specify from which language the title comes')
-.parse(process.argv)
+program.process('wikiqid')
 
 const args = program.args
 if (args.length === 0) return program.help()
@@ -15,12 +11,11 @@ const wdk = require('wikidata-sdk')
 const copy = require('../lib/copy')
 const breq = require('bluereq')
 const error_ = require('../lib/error')
-const localLang = require('../lib/local_lang')
 const _ = require('lodash')
 const getRedirectedWikipediaTitle = require('../lib/get_redirected_wikipedia_title')
 
 const last = args.slice(-1)[0]
-var lang = program.lang || localLang || 'en'
+var lang = program.lang
 
 // allow to pass a title without having to put it in ""
 var title = args.join(' ')

--- a/lib/program.js
+++ b/lib/program.js
@@ -1,0 +1,30 @@
+/**
+ * Extends commander with options and functions used by all subcommands.
+ */
+const program = require('commander')
+const strings = require('../lib/strings')
+
+const help = program.help
+
+program.option('-l, --lang <lang>', 'specify the language to use')
+program.process = command => {
+  if (command) {
+    program.arguments(strings[command].args)
+    program.description(strings[command].description)
+    var examples = strings[command].examples
+    if (examples && examples.length) {
+      program.on('--help', () => {
+        console.log('  Examples:');
+        console.log('');
+        examples.forEach( (example) => {
+          console.log('    $ wd %s %s', command, example);
+        })
+        console.log('');
+      })
+    }
+  }
+  program.parse(process.argv)
+  program.lang = program.lang || require('../lib/local_lang') || 'en'
+}
+
+module.exports = program

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -5,7 +5,10 @@ module.exports = {
   },
   claims: {
     args: '<entity> [property]',
-    description: 'display the claims of an entity'
+    description: 'display the claims of an entity',
+    examples: [
+      'Q12345'
+    ]
   },
   data: {
     args: '<entity>',


### PR DESCRIPTION
Includes common options and display of examples (#12).

`lib/program.js` may be extended to avoid more code duplication.