### PR TITLE
README use --rm for docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Installing globally allows to make the command `wd` accessible from your shell `
 ### via docker
 ```sh
 # Might require to be run with sudo depending on your Docker installation
-docker run -t maxlath/wikidata-cli
+docker run --rm -t maxlath/wikidata-cli
 # You can make an alias out of it:
-alias wd="docker run -t maxlath/wikidata-cli"
+alias wd="docker run --rm -t maxlath/wikidata-cli"
 ```
 
 ## Commands


### PR DESCRIPTION
With --rm once the command has run the container is removed.
Without --rm you will end up with a new container that remains in place for each command run.
You can see these with "docker container ls --all"